### PR TITLE
mqe 57 - use timestamp for date message was received

### DIFF
--- a/src/main/java/org/immregistries/dqa/hub/report/viewer/MessageMetadata.java
+++ b/src/main/java/org/immregistries/dqa/hub/report/viewer/MessageMetadata.java
@@ -28,7 +28,7 @@ public class MessageMetadata {
   @Lob
   private String response;
 
-  @javax.persistence.Temporal(TemporalType.DATE)
+  @javax.persistence.Temporal(TemporalType.TIMESTAMP)
   private Date inputTime;
 
   @NotNull

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,3 @@
+-- alter table message_metadata alter column input_time type TIMESTAMP(23, 10);
+-- alter table message_metadata alter column input_time type DATE(8);
+select 1 from dual;


### PR DESCRIPTION
This updates the schema for MessageMetadata to use a timestamp instead of Date field. 