### PR TITLE
2018.4 Bugfix - add an MSH-4 default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>1.3.3.RELEASE</version>
   </parent>
   <groupId>org.immregistries</groupId>
-  <version>2018.3-BETA</version>
+  <version>2018.4-BETA</version>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>dqa-message-hub</artifactId>
   <packaging>war</packaging>
@@ -43,13 +43,13 @@
     <dependency>
       <groupId>org.immregistries</groupId>
       <artifactId>dqa-validator</artifactId>
-      <version>2018.3-BETA</version>
+      <version>2018.4-BETA</version>
     </dependency>
 
     <dependency>
       <groupId>org.immregistries</groupId>
       <artifactId>dqa-hl7-utility</artifactId>
-      <version>2018.3</version>
+      <version>2018.4</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/immregistries/dqa/hub/submission/FileInputController.java
+++ b/src/main/java/org/immregistries/dqa/hub/submission/FileInputController.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+import org.apache.commons.lang3.StringUtils;
 import org.immregistries.dqa.hl7util.parser.HL7QuickParser;
 import org.immregistries.dqa.hub.rest.FileUploadData;
 import org.immregistries.dqa.hub.rest.MessageInputController;
@@ -198,8 +199,12 @@ public class FileInputController {
             return fileUpload;
           }
         }
+        String sender = quickParser.getMsh4Sender(message);
+        if (StringUtils.isBlank(sender)) {
+          sender = "Unspecified";
+        }
         String ackResult = messageController
-            .urlEncodedHttpFormPost(message, null, null, fileUpload.getFacilityId());
+            .urlEncodedHttpFormPost(message, null, null, sender);
 
         //If the ack ends with a line break, remove it.
         ackResult = ackResult.replaceAll("\\r$", "");


### PR DESCRIPTION
This was a bug that prevented the UI from working if messages were submitted without an MSH-4 value. 